### PR TITLE
New Source and Constraint API

### DIFF
--- a/scarlet/__init__.py
+++ b/scarlet/__init__.py
@@ -1,5 +1,5 @@
 # convenience: get vanilla NMF and deblend wrapper directly within scarlet
 from proxmin import nmf as nmf
 from .constraints import *
-from .source import Source
+from .source import *
 from .blend import Blend

--- a/scarlet/__init__.py
+++ b/scarlet/__init__.py
@@ -1,4 +1,5 @@
 # convenience: get vanilla NMF and deblend wrapper directly within scarlet
 from proxmin import nmf as nmf
+from .constraints import *
 from .source import Source
 from .blend import Blend

--- a/scarlet/blend.py
+++ b/scarlet/blend.py
@@ -73,7 +73,6 @@ class Blend(object):
 
         # set up data structures
         self.set_data(img, weights=weights, sky=sky, bg_rms=bg_rms)
-        self.init_sources()
 
     def source_of(self, k):
         """Get the indices of model component k.
@@ -118,10 +117,16 @@ class Blend(object):
         proxs_g_S = [None] * self.K
         for k in range(self.K):
             m,l = self.source_of(k)
-            if self.sources[m].proxs_g_A is not None:
-                proxs_g_A[k] = self.sources[m].proxs_g_A[l]
-            if self.sources[m].proxs_g_S is not None:
-                proxs_g_S[k] = self.sources[m].proxs_g_S[l]
+            try:
+                if self.sources[m].proxs_g_A is not None:
+                    proxs_g_A[k] = self.sources[m].proxs_g_A[l]
+            except AttributeError:
+                pass
+            try:
+                if self.sources[m].proxs_g_S is not None:
+                    proxs_g_S[k] = self.sources[m].proxs_g_S[l]
+            except AttributeError:
+                pass
         return proxs_g_A + proxs_g_S
 
     @property
@@ -135,10 +140,16 @@ class Blend(object):
         LS = [None] * self.K
         for k in range(self.K):
             m,l = self.source_of(k)
-            if self.sources[m].LA is not None:
-                LA[k] = self.sources[m].LA[l]
-            if self.sources[m].LS is not None:
-                LS[k] = self.sources[m].LS[l]
+            try:
+                if self.sources[m].LA is not None:
+                    LA[k] = self.sources[m].LA[l]
+            except AttributeError:
+                pass
+            try:
+                if self.sources[m].LS is not None:
+                    LS[k] = self.sources[m].LS[l]
+            except AttributeError:
+                pass
         return LA + LS
 
     def fit(self, steps=200, e_rel=None, max_iter=None):
@@ -247,12 +258,6 @@ class Blend(object):
             assert len(bg_rms) == self.B
             self._bg_rms = np.array(bg_rms)
         self._set_weights(weights)
-
-    def init_sources(self):
-        """Initialize the model for each source.
-        """
-        for m in range(self.M):
-            self.sources[m].init_source(self, self._img)
 
     def get_model(self, m=None, combine=True, combine_source_components=True, use_sed=True, flat=True):
         """Compute the current model for the entire image.

--- a/scarlet/blend.py
+++ b/scarlet/blend.py
@@ -163,7 +163,7 @@ class Blend(object):
             the internal reference to that list.
         """
         try:
-            self.it += 1
+            self.it # test of this is first time fit is called
         except AttributeError:
             self.it = 0
             self._model_it = -1

--- a/scarlet/constraints.py
+++ b/scarlet/constraints.py
@@ -119,6 +119,9 @@ class ConstraintList:
         for c in constraints:
             self.__iand__(c)
 
+    def __getitem__(self, index):
+        return self.constraints[index]
+
     def __and__(self, c):
         cl = ConstraintList(self.constraints)
         return cl.__iand__(c)
@@ -143,9 +146,10 @@ class ConstraintList:
             else:
                 # self.prox_sed is AlternatingProjections
                 if isinstance(c.prox_sed, proxmin.operators.AlternatingProjections):
-                    self.prox_sed.operators += c.prox_sed.operators
+                    ops = self.prox_sed.operators + c.prox_sed.operators
                 else:
-                    self.prox_sed.operators.append(c.prox_sed)
+                    ops = self.prox_sed.operators + [c.prox_sed]
+                self.prox_sed = proxmin.operators.AlternatingProjections(ops)
 
         if c.prox_morph is not None:
             if self.prox_morph is None:
@@ -158,11 +162,12 @@ class ConstraintList:
                     ops = [self.prox_morph, c.prox_morph]
                 self.prox_morph = proxmin.operators.AlternatingProjections(ops)
             else:
-                # self.prox_sed is AlternatingProjections
+                # self.prox_morph is AlternatingProjections
                 if isinstance(c.prox_morph, proxmin.operators.AlternatingProjections):
-                    self.prox_morph.operators += c.prox_morph.operators
+                    ops = self.prox_morph.operators + c.prox_morph.operators
                 else:
-                    self.prox_morph.operators.append(c.prox_morph)
+                    ops = self.prox_morph.operators + [c.prox_morph]
+                self.prox_morph = proxmin.operators.AlternatingProjections(ops)
 
         if c.prox_g_sed is not None:
             if self.prox_g_sed is None:

--- a/scarlet/constraints.py
+++ b/scarlet/constraints.py
@@ -187,6 +187,7 @@ class ConstraintList:
                 self.L_morph = [c.L_morph]
             else:
                 self.L_morph.append(c.L_morph)
+        return self
 
     def reset(self, source):
         for c in self.constraints:

--- a/scarlet/constraints.py
+++ b/scarlet/constraints.py
@@ -5,11 +5,11 @@ from functools import partial
 
 class Constraint(object):
     def __init__(self):
-        self.prox_sed = None # might be None, single operator, or AlternatingProjections
+        self.prox_sed = None  # None, single operator, or AlternatingProjections
         self.prox_morph = None
-        self.prox_g_sed = None
+        self.prox_g_sed = None # None or operator
         self.prox_g_morph = None
-        self.L_sed = None
+        self.L_sed = None      # None or matrix
         self.L_morph = None
 
     def reset(self, source):
@@ -111,9 +111,9 @@ class ConstraintList:
     def __init__(self, constraints):
         self.prox_sed = None # might be None, single operator, or AlternatingProjections
         self.prox_morph = None
-        self.prox_g_sed = None
+        self.prox_g_sed = None # None or list of operators
         self.prox_g_morph = None
-        self.L_sed = None
+        self.L_sed = None # None or list of matrices
         self.L_morph = None
         self.constraints = []
         for c in constraints:

--- a/scarlet/constraints.py
+++ b/scarlet/constraints.py
@@ -72,7 +72,7 @@ class MonotonicityConstraint(Constraint):
         # lazy initialization: wait for the reset to set the source size
         self.use_nearest = use_nearest
 
-    def resize(self, source):
+    def reset(self, source):
         shape = source.shape[1:]
         self.L_morph = transformations.getRadialMonotonicOp(shape, useNearest=self.use_nearest)
 
@@ -82,7 +82,7 @@ class SymmetryConstraint(Constraint):
         self.prox_g_morph = proxmin.operators.prox_zero
         # lazy initialization: wait for the reset to set the source size
 
-    def resize(self, source):
+    def reset(self, source):
         shape = source.shape[1:]
         self.L_morph = transformations.getSymmetryOp(shape)
 
@@ -92,7 +92,7 @@ class TVxConstraint(Constraint):
         self.proxs_g_morph = partial(proxmin.operators.prox_soft, thresh=thresh)
         # lazy initialization: wait for the reset to set the source size
 
-    def resize(self, source):
+    def reset(self, source):
         shape = source.shape[1:]
         self.L_morph = proxmin.transformations.get_gradient_x(shape, source.Nx)
 
@@ -102,7 +102,7 @@ class TVyConstraint(Constraint):
         self.proxs_g_morph = partial(proxmin.operators.prox_soft, thresh=thresh)
         # lazy initialization: wait for the reset to set the source size
 
-    def resize(self, source):
+    def reset(self, source):
         shape = source.shape[1:]
         self.L_morph = proxmin.transformations.get_gradient_y(shape, source.Ny)
 

--- a/scarlet/constraints.py
+++ b/scarlet/constraints.py
@@ -1,0 +1,194 @@
+import proxmin
+from . import operators
+from . import transformations
+from functools import partial
+
+class Constraint(object):
+    def __init__(self):
+        self.prox_sed = None # might be None, single operator, or AlternatingProjections
+        self.prox_morph = None
+        self.prox_g_sed = None
+        self.prox_g_morph = None
+        self.L_sed = None
+        self.L_morph = None
+
+    def reset(self, source):
+        pass
+
+    def __and__(self, c):
+        if isinstance(c, Constraint):
+            return ConstraintList([self, c])
+        else:
+            raise NotImplementedError
+
+class MinimalConstraint(Constraint):
+    def __init__(self):
+        super(MinimalConstraint, self).__init__()
+        self.prox_morph = proxmin.operators.prox_plus
+        self.prox_sed = proxmin.operators.prox_unity_plus
+
+class PositivityConstraint(Constraint):
+    def __init__(self):
+        super(PositivityConstraint, self).__init__()
+        self.prox_morph = proxmin.operators.AlternatingProjections([operators.prox_center_on, proxmin.operators.prox_plus])
+
+class SimpleConstraint(PositivityConstraint):
+    def __init__(self):
+        super(SimpleConstraint, self).__init__()
+        self.prox_sed = proxmin.operators.prox_unity_plus
+
+class L0Constraint(Constraint):
+    def __init__(self, thresh):
+        super(L0Constraint, self).__init__()
+        self.prox_morph = partial(proxmin.operators.prox_hard, thresh=thresh)
+
+class L1Constraint(Constraint):
+    def __init__(self, thresh):
+        super(L1Constraint, self).__init__()
+        self.prox_morph = partial(proxmin.operators.prox_soft, thresh=thresh)
+
+class DirectMonotonicityConstraint(Constraint):
+    def __init__(self, use_nearest=False, exact=False, thresh=0):
+        super(DirectMonotonicityConstraint, self).__init__()
+        self.use_nearest = use_nearest
+        self.exact = exact
+        self.thresh = thresh
+        # lazy initialization: wait for the reset to set the source size
+
+    def reset(self, source):
+        shape = source.shape[1:]
+        if not self.exact:
+            self.prox_morph = operators.prox_strict_monotonic(shape, use_nearest=self.use_nearest, thresh=self.thresh)
+        else:
+            # cone method for monotonicity: exact but VERY slow
+            G = transformations.getRadialMonotonicOp(shape, useNearest=self.useNearest).toarray()
+            self.prox_morphh = partial(operators.prox_cone, G=G)
+
+class MonotonicityConstraint(Constraint):
+    def __init__(self, use_nearest=False):
+        super(MonotonicityConstraint, self).__init__()
+        # positive radial gradients:
+        self.prox_g_morph = proxmin.operators.prox_plus
+        # lazy initialization: wait for the reset to set the source size
+        self.use_nearest = use_nearest
+
+    def resize(self, source):
+        shape = source.shape[1:]
+        self.L_morph = transformations.getRadialMonotonicOp(shape, useNearest=self.use_nearest)
+
+class SymmetryConstraint(Constraint):
+    def __init__(self):
+        super(SymmetryConstraint, self).__init__()
+        self.prox_g_morph = proxmin.operators.prox_zero
+        # lazy initialization: wait for the reset to set the source size
+
+    def resize(self, source):
+        shape = source.shape[1:]
+        self.L_morph = transformations.getSymmetryOp(shape)
+
+class TVxConstraint(Constraint):
+    def __init__(self, thresh=0):
+        super(DirectMonotonicityConstraint, self).__init__()
+        self.proxs_g_morph = partial(proxmin.operators.prox_soft, thresh=thresh)
+        # lazy initialization: wait for the reset to set the source size
+
+    def resize(self, source):
+        shape = source.shape[1:]
+        self.L_morph = proxmin.transformations.get_gradient_x(shape, source.Nx)
+
+class TVyConstraint(Constraint):
+    def __init__(self, thresh=0):
+        super(DirectMonotonicityConstraint, self).__init__()
+        self.proxs_g_morph = partial(proxmin.operators.prox_soft, thresh=thresh)
+        # lazy initialization: wait for the reset to set the source size
+
+    def resize(self, source):
+        shape = source.shape[1:]
+        self.L_morph = proxmin.transformations.get_gradient_y(shape, source.Ny)
+
+
+class ConstraintList:
+    def __init__(self, constraints):
+        self.prox_sed = None # might be None, single operator, or AlternatingProjections
+        self.prox_morph = None
+        self.prox_g_sed = None
+        self.prox_g_morph = None
+        self.L_sed = None
+        self.L_morph = None
+        self.constraints = []
+        for c in constraints:
+            self.__iand__(c)
+
+    def __and__(self, c):
+        cl = ConstraintList(self.constraints)
+        return cl.__iand__(c)
+
+    def __iand__(self, c):
+        if isinstance(c, ConstraintList):
+            for _c in c.constraints:
+                self.__iand__(_c)
+            return self
+
+        self.constraints.append(c)
+        if c.prox_sed is not None:
+            if self.prox_sed is None:
+                self.prox_sed = c.prox_sed
+            elif isinstance(self.prox_sed, proxmin.operators.AlternatingProjections) is False:
+                # self.prox_sed is single operator
+                if isinstance(c.prox_sed, proxmin.operators.AlternatingProjections):
+                    ops = [self.prox_sed] + c.prox_sed.operators
+                else:
+                    ops = [self.prox_sed, c.prox_sed]
+                self.prox_sed = proxmin.operators.AlternatingProjections(ops)
+            else:
+                # self.prox_sed is AlternatingProjections
+                if isinstance(c.prox_sed, proxmin.operators.AlternatingProjections):
+                    self.prox_sed.operators += c.prox_sed.operators
+                else:
+                    self.prox_sed.operators.append(c.prox_sed)
+
+        if c.prox_morph is not None:
+            if self.prox_morph is None:
+                self.prox_morph = c.prox_morph
+            elif isinstance(self.prox_morph, proxmin.operators.AlternatingProjections) is False:
+                # self.prox_morph is single operator
+                if isinstance(c.prox_morph, proxmin.operators.AlternatingProjections):
+                    ops = [self.prox_morph] + c.prox_morph.operators
+                else:
+                    ops = [self.prox_morph, c.prox_morph]
+                self.prox_morph = proxmin.operators.AlternatingProjections(ops)
+            else:
+                # self.prox_sed is AlternatingProjections
+                if isinstance(c.prox_morph, proxmin.operators.AlternatingProjections):
+                    self.prox_morph.operators += c.prox_morph.operators
+                else:
+                    self.prox_morph.operators.append(c.prox_morph)
+
+        if c.prox_g_sed is not None:
+            if self.prox_g_sed is None:
+                self.prox_g_sed = [c.prox_g_sed]
+            else:
+                self.prox_g_sed.append(c.prox_g_sed)
+
+        if c.prox_g_morph is not None:
+            if self.prox_g_morph is None:
+                self.prox_g_morph = [c.prox_g_morph]
+            else:
+                self.prox_g_morph.append(c.prox_g_morph)
+
+        if c.L_sed is not None:
+            if self.L_sed is None:
+                self.L_sed = [c.L_sed]
+            else:
+                self.L_sed.append(c.L_sed)
+
+        if c.L_morph is not None:
+            if self.L_morph is None:
+                self.L_morph = [c.L_morph]
+            else:
+                self.L_morph.append(c.L_morph)
+
+    def reset(self, source):
+        for c in self.constraints:
+            c.reset(source)
+        self.__init__(self.constraints)

--- a/scarlet/operators.py
+++ b/scarlet/operators.py
@@ -1,10 +1,10 @@
 from __future__ import print_function, division
-import logging
 from functools import partial
 
 import numpy as np
 import proxmin
 
+import logging
 logger = logging.getLogger("scarlet.operators")
 
 def _prox_strict_monotonic(X, step, ref_idx, dist_idx, thresh=0):

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -139,17 +139,14 @@ def init_above_noise(source, img, bg_rms, thresh=1., symmetric=True, monotonic=T
     ypix, xpix = np.where(mask)
     _Ny = np.max(ypix)-np.min(ypix)
     _Nx = np.max(xpix)-np.min(xpix)
-    # make sure source has off pixel numbers
+    # make sure source has odd pixel numbers
     _Ny += 1 - _Ny % 2
     _Nx += 1 - _Nx % 2
 
     # get the model of the source
     source._set_frame(source.center, (_Ny, _Nx))
-    #source.morph = np.zeros((source.K, _Ny * _Nx))
     Dy, Dx = Ny - _Ny, Nx - _Nx
     inner = (slice(Dy//2, -Dy//2), slice(Dx//2, -Dx//2))
-    #source.morph[0] = morph[inner].flatten()
-    #source.set_center(source.center)
     morph = morph[inner]
 
     # updated SED with mean sed under weight function morph

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import setuptools
 import subprocess
 
 # Use the firt 7 digits of the git hash to set the version
-__version__ = '0.1.'+subprocess.check_output(['git', 'rev-parse', 'HEAD'])[:7].decode("utf-8")
+__version__ = '0.2.'+subprocess.check_output(['git', 'rev-parse', 'HEAD'])[:7].decode("utf-8")
 
 packages = []
 for root, dirs, files in os.walk('.'):


### PR DESCRIPTION
This PR alters the API for `Source` in order to simplify the initialization sequence and especially break the dependency on Blend to perform the source initialization. It offers more flexibility to use different initialization functions and clarify what needs to be present for a proper Source.

It does that by defining a base class `Source`, which can be constructed only if sed, morphology, center, and constraints are defined. It's the duty of any derived class to do so. For convenience, I've implemented `PointSource` and `ExtendedSource`, with default inits and constraints (positivity, symmetry, monotonicity) that we've been using on sims and real data.

For good measure, I've also cleaned up the constraints specification. Instead of an undocumented dict, we now have a `Constraint` base class and derived classes, e.g. `L1Constraint`, with all necessary arguments. They can be combined with the `&` operator to create a `ConstraintList`, which is what `Source` expects to get.

These changes substantially clarify both `Source` and `Constraint` behavior and will make it straightforward to move some of the constraint operations to the C++ layer.