### PR TITLE
Abstract constraints

### DIFF
--- a/scarlet/cache.py
+++ b/scarlet/cache.py
@@ -1,0 +1,28 @@
+class Cache:
+    """Cache to hold all complex proximal operators, transformation etc.
+
+    Convention to use is that the lookup `name` refers to the class or method
+    that pushes content onto the cache, the `key` can be chosen at will.
+
+    """
+    _cache = {}
+
+    @staticmethod
+    def check(name, key):
+        try:
+            Cache._cache[name]
+        except KeyError:
+            Cache._cache[name] = {}
+        return Cache._cache[name][key]
+
+    @staticmethod
+    def set(name, key, content):
+        try:
+            Cache._cache[name]
+        except KeyError:
+            Cache._cache[name] = {}
+        Cache._cache[name][key] = content
+
+    @staticmethod
+    def __repr__(self):
+        repr(Cache._cache)

--- a/scarlet/constraints.py
+++ b/scarlet/constraints.py
@@ -29,17 +29,6 @@ class Constraint(object):
     def L_morph(self, shape):
         return None
 
-    def __and__(self, c):
-        """Combine multiple constraints
-        """
-        if isinstance(c, Constraint):
-            return [self, c]
-        elif isinstance(c, list) and all([isinstance(c_, Constraint) for c_ in c]):
-            return [self] + c
-        else:
-            raise NotImplementedError("second argument must be constraint or list of constraints")
-
-
 class MinimalConstraint(Constraint):
     """The minimal constraint for sources.
 
@@ -269,7 +258,7 @@ class ConstraintAdapter(object):
             _C = [C]
         else:
             _C = C
-        if isinstance(_C, list) and all([isinstance(_c, Constraint) for _c in _C]):
+        if hasattr(_C, '__iter__') and all([isinstance(_c, Constraint) for _c in _C]):
             self.C = _C
         else:
             raise NotImplementedError("argument `C` must be constraint or list of constraints")

--- a/scarlet/constraints.py
+++ b/scarlet/constraints.py
@@ -276,14 +276,26 @@ class ConstraintAdapter(object):
         if not isinstance(self.C, list):
             return self.C.prox_sed(self.source.sed[0].shape)
         else:
-            return proxmin.operators.AlternatingProjections([c.prox_sed(self.source.sed[0].shape) for c in self.C])
+            ops = [ c.prox_sed(self.source.sed[0].shape) for c in self.C if c.prox_sed(self.source.sed[0].shape) is not proxmin.operators.prox_id ]
+            if len(ops) == 0:
+                return proxmin.operators.prox_id
+            if len(ops) == 1:
+                return ops[0]
+            else:
+                return proxmin.operators.AlternatingProjections(ops)
 
     @property
     def prox_morph(self):
         if not isinstance(self.C, list):
             return self.C.prox_morph(self.source.morph[0].shape)
         else:
-            return proxmin.operators.AlternatingProjections([c.prox_morph(self.source.morph[0].shape) for c in self.C])
+            ops = [ c.prox_morph(self.source.morph[0].shape) for c in self.C if c.prox_morph(self.source.morph[0].shape) is not proxmin.operators.prox_id ]
+            if len(ops) == 0:
+                return proxmin.operators.prox_id
+            if len(ops) == 1:
+                return ops[0]
+            else:
+                return proxmin.operators.AlternatingProjections(ops)
 
     @property
     def prox_g_sed(self):

--- a/scarlet/constraints.py
+++ b/scarlet/constraints.py
@@ -26,27 +26,27 @@ class ConstraintAdapter(object):
 
     @property
     def prox_sed(self):
-        return self.C.prox_sed(self.source.sed.shape)
+        return self.C.prox_sed(self.source.sed[0].shape)
 
     @property
     def prox_morph(self):
-        return self.C.prox_morph(self.source.morph.shape)
+        return self.C.prox_morph(self.source.morph[0].shape)
 
     @property
     def prox_g_sed(self):
-        return self.C.prox_g_sed(self.source.sed.shape)
+        return self.C.prox_g_sed(self.source.sed[0].shape)
 
     @property
     def prox_g_morph(self):
-        return self.C.prox_g_morph(self.source.morph.shape)
+        return self.C.prox_g_morph(self.source.morph[0].shape)
 
     @property
     def L_sed(self):
-        return self.C.L_sed(self.source.sed.shape)
+        return self.C.L_sed(self.source.sed[0].shape)
 
     @property
     def L_morph(self):
-        return self.C.L_morph(self.source.morph.shape)
+        return self.C.L_morph(self.source.morph[0].shape)
 
     def __repr__(self):
         return repr(self.C)

--- a/scarlet/constraints.py
+++ b/scarlet/constraints.py
@@ -234,6 +234,7 @@ class TVxConstraint(Constraint):
             return check_cache(name, key)
         except KeyError:
             L = proxmin.transformations.get_gradient_x(shape, shape[1])
+            _ = L.spectral_norm
             cache[name][key] = L
             return L
 
@@ -263,6 +264,7 @@ class TVyConstraint(Constraint):
             return check_cache(name, key)
         except KeyError:
             L = proxmin.transformations.get_gradient_y(shape, shape[0])
+            _ = L.spectral_norm
             cache[name][key] = L
             return L
 

--- a/scarlet/constraints.py
+++ b/scarlet/constraints.py
@@ -265,65 +265,51 @@ class ConstraintAdapter(object):
     def __init__(self, C, source):
         """Initialize the constraint adapter.
         """
-        if isinstance(C, Constraint) or (isinstance(C, list) and all([isinstance(c_, Constraint) for c_ in C])):
-            self.C = C
+        if isinstance(C, Constraint):
+            _C = [C]
+        else:
+            _C = C
+        if isinstance(_C, list) and all([isinstance(_c, Constraint) for _c in _C]):
+            self.C = _C
         else:
             raise NotImplementedError("argument `C` must be constraint or list of constraints")
         self.source = source
 
     @property
     def prox_sed(self):
-        if not isinstance(self.C, list):
-            return self.C.prox_sed(self.source.sed[0].shape)
+        ops = [c.prox_sed(self.source.sed[0].shape) for c in self.C if c.prox_sed(self.source.sed[0].shape) is not proxmin.operators.prox_id]
+        if len(ops) == 0:
+            return proxmin.operators.prox_id
+        if len(ops) == 1:
+            return ops[0]
         else:
-            ops = [ c.prox_sed(self.source.sed[0].shape) for c in self.C if c.prox_sed(self.source.sed[0].shape) is not proxmin.operators.prox_id ]
-            if len(ops) == 0:
-                return proxmin.operators.prox_id
-            if len(ops) == 1:
-                return ops[0]
-            else:
-                return proxmin.operators.AlternatingProjections(ops)
+            return proxmin.operators.AlternatingProjections(ops)
 
     @property
     def prox_morph(self):
-        if not isinstance(self.C, list):
-            return self.C.prox_morph(self.source.morph[0].shape)
+        ops = [c.prox_morph(self.source.morph[0].shape) for c in self.C if c.prox_morph(self.source.morph[0].shape) is not proxmin.operators.prox_id]
+        if len(ops) == 0:
+            return proxmin.operators.prox_id
+        if len(ops) == 1:
+            return ops[0]
         else:
-            ops = [ c.prox_morph(self.source.morph[0].shape) for c in self.C if c.prox_morph(self.source.morph[0].shape) is not proxmin.operators.prox_id ]
-            if len(ops) == 0:
-                return proxmin.operators.prox_id
-            if len(ops) == 1:
-                return ops[0]
-            else:
-                return proxmin.operators.AlternatingProjections(ops)
+            return proxmin.operators.AlternatingProjections(ops)
 
     @property
     def prox_g_sed(self):
-        if not isinstance(self.C, list):
-            return self.C.prox_g_sed(self.source.sed[0].shape)
-        else:
-            return [ c.prox_g_sed(self.source.sed[0].shape) for c in self.C if c.prox_g_sed(self.source.sed[0].shape) is not None ]
+        return [c.prox_g_sed(self.source.sed[0].shape) for c in self.C if c.prox_g_sed(self.source.sed[0].shape) is not None]
 
     @property
     def prox_g_morph(self):
-        if not isinstance(self.C, list):
-            return self.C.prox_g_morph(self.source.morph[0].shape)
-        else:
-            return [ c.prox_g_morph(self.source.morph[0].shape) for c in self.C if c.prox_g_morph(self.source.morph[0].shape) is not None ]
+        return [c.prox_g_morph(self.source.morph[0].shape) for c in self.C if c.prox_g_morph(self.source.morph[0].shape) is not None]
 
     @property
     def L_sed(self):
-        if not isinstance(self.C, list):
-            return self.C.L_sed(self.source.sed[0].shape)
-        else:
-            return [ c.L_sed(self.source.sed[0].shape) for c in self.C if c.prox_g_sed(self.source.sed[0].shape) is not None ]
+        return [c.L_sed(self.source.sed[0].shape) for c in self.C if c.prox_g_sed(self.source.sed[0].shape) is not None]
 
     @property
     def L_morph(self):
-        if not isinstance(self.C, list):
-            return self.C.L_morph(self.source.morph[0].shape)
-        else:
-            return [c.L_morph(self.source.morph[0].shape) for c in self.C if c.prox_g_morph(self.source.morph[0].shape) is not None ]
+        return [c.L_morph(self.source.morph[0].shape) for c in self.C if c.prox_g_morph(self.source.morph[0].shape) is not None]
 
     def __repr__(self):
         return repr(self.C)

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -87,7 +87,6 @@ class Source(object):
 
         # updates for sed or morph?
         self.set_fix(fix_sed, fix_morph)
-        # needs to set constraints when shape of source is known
         self.set_constraints(constraints)
 
     @property
@@ -183,24 +182,6 @@ class Source(object):
             self.constraints += constraints
         else:
             raise NotImplementedError("constraint %r not understood" % constraints)
-
-        # reset constaints once source size is known
-        # also check if prox_sed and prox_morph are set in constraints
-        if extend == 0:
-            range_ = range(self.K)
-        else:
-            range_ = range(self.K, self.K + K)
-
-        for k in range_:
-            if self.constraints[k].prox_sed is None or self.constraints[k].prox_morph is None:
-                self.constraints[k] &= sc.SimpleConstraint()
-            self.constraints[k].reset(self)
-
-    def reset_constraints(self):
-        """Iterate through all constraints and call their `reset` method
-        """
-        for k in range(self.K):
-            self.constraints[k].reset(self)
 
     def add_component(self, sed, morph, constraints=None, fix_sed=False, fix_morph=False):
         """Extend Source by adding component(s).
@@ -394,9 +375,6 @@ class Source(object):
 
             # update Gamma and center (including subpixel shifts)
             self.set_center(self.center)
-
-            # set constraints
-            self.reset_constraints()
 
     def get_morph_error(self, weights):
         """Get error in the morphology

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -177,8 +177,6 @@ class Source(object):
         if constraints is None:
             constraints = sc.SimpleConstraint()
 
-        assert isinstance(constraints, sc.Constraint)
-
         self.constraints = [sc.ConstraintAdapter(constraints, self)] * K
 
     def add_component(self, sed, morph, constraints=None, fix_sed=False, fix_morph=False):

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -175,13 +175,11 @@ class Source(object):
             K = extend
 
         if constraints is None:
-            self.constraints += [sc.SimpleConstraint()] * K
-        elif isinstance(constraints, sc.Constraint) or isinstance(constraints, sc.ConstraintList):
-            self.constraints += [constraints] * K
-        elif len(constraints) == K:
-            self.constraints += constraints
-        else:
-            raise NotImplementedError("constraint %r not understood" % constraints)
+            constraints = sc.SimpleConstraint()
+
+        assert isinstance(constraints, sc.Constraint)
+
+        self.constraints = [sc.ConstraintAdapter(constraints, self)] * K
 
     def add_component(self, sed, morph, constraints=None, fix_sed=False, fix_morph=False):
         """Extend Source by adding component(s).

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -544,9 +544,9 @@ class PointSource(Source):
         sed, morph = self._make_initial(img, shape)
 
         if constraints is None:
-            constraints = (sc.SimpleConstraint()
-                           & sc.DirectMonotonicityConstraint(use_nearest=False)
-                           & sc.DirectSymmetryConstraint())
+            constraints = (sc.SimpleConstraint(),
+                           sc.DirectMonotonicityConstraint(use_nearest=False),
+                           sc.DirectSymmetryConstraint())
 
         super(PointSource, self).__init__(sed, morph, center=center, constraints=constraints, psf=psf,
                                           fix_sed=False, fix_morph=False, fix_frame=False, shift_center=0.1)
@@ -614,8 +614,8 @@ class ExtendedSource(Source):
                                         monotonic=monotonic, config=config)
 
         if constraints is None:
-            constraints = (sc.SimpleConstraint() &
-                           sc.DirectMonotonicityConstraint(use_nearest=False) &
+            constraints = (sc.SimpleConstraint(),
+                           sc.DirectMonotonicityConstraint(use_nearest=False),
                            sc.DirectSymmetryConstraint())
 
         super(ExtendedSource, self).__init__(sed, morph, center=center, constraints=constraints, psf=psf,

--- a/scarlet/transformations.py
+++ b/scarlet/transformations.py
@@ -449,7 +449,7 @@ def getSymmetryOp(shape):
     except KeyError:
         idx = np.arange(shape[0]*shape[1])
         sidx = idx[::-1]
-        symmetryOp = getIdentityOp(shape)
+        symmetryOp = getIdentityOp(shape).L
         symmetryOp -= scipy.sparse.coo_matrix((np.ones(size),(idx, sidx)), shape=(size,size))
         symmetryOp = proxmin.utils.MatrixAdapter(symmetryOp, axis=1)
         global cache

--- a/scarlet/transformations.py
+++ b/scarlet/transformations.py
@@ -349,58 +349,13 @@ class LinearOperator(proxmin.utils.MatrixAdapter):
     def __init__(self, L):
         """Initialize the class
         """
-        while isinstance(L, LinearOperator):
-            L = L.L
-        self.L = L
-        self.axis = 1
-
-    """
-    def dot(self, X):
-        Take the dot product with a 2D X
-        if isinstance(X, np.ndarray):
-            return self.L.dot(X.reshape(-1)).reshape(X.shape)
-        else:
-            return self.L.dot(X)
-    """
+        super(LinearOperator, self).__init__(L, axis=1)
 
     @property
     def T(self):
         """Return a transposed version of the linear operator
         """
         return LinearOperator(self.L.T)
-
-    @property
-    def spectral_norm(self):
-        """Spectral norm of the operator
-        """
-        from scipy.sparse import issparse
-        LTL = self.L.T.dot(self.L)
-        if issparse(self.L):
-            if min(self.L.shape) <= 2:
-                L2 = np.real(np.linalg.eigvals(LTL.toarray()).max())
-            else:
-                import scipy.sparse.linalg
-                L2 = np.real(scipy.sparse.linalg.eigs(LTL, k=1, return_eigenvectors=False)[0])
-        else:
-            import IPython; IPython.embed()
-            L2 = np.real(np.linalg.eigvals(LTL).max())
-        return L2
-
-    def __len__(self):
-        return len(self.L)
-
-    @property
-    def shape(self):
-        return self.L.shape
-
-    @property
-    def size(self):
-        return self.L.size
-
-    @property
-    def ndim(self):
-        print(self.L.ndim)
-        return self.L.ndim
 
     def __sub__(self, op):
         return LinearOperator(self.L - op)
@@ -429,12 +384,6 @@ class LinearOperator(proxmin.utils.MatrixAdapter):
     def reshape(self, shape):
         return LinearOperator(self.L.reshape(shape))
 
-    def __array_prepare__(self, *args):
-        return self.L.__array_prepare__(*args)
-
-    def __getattr__(self, attr):
-        if attr not in self.__dict__.keys:
-            return getattr(self.L, attr)
 
 def getPSFOp(psf, imgShape):
     """Create an operator to convolve intensities with the PSF

--- a/scarlet/transformations.py
+++ b/scarlet/transformations.py
@@ -107,7 +107,7 @@ class LinearFilter:
         X: 2D numpy array or `LinearFilter` or `LinearFilterChain`
             Array to apply the filter to, or chain of filters to
             prepend this filter to.
-        
+
         Returns
         -------
         result: 2D numpy array or `LinearFilterChain`
@@ -147,7 +147,7 @@ class LinearFilterChain:
             applied to an image first.
         """
         self.filters = filters
-    
+
     @property
     def T(self):
         """Transpose the list of filters
@@ -168,7 +168,7 @@ class LinearFilterChain:
         ----------
         X: 2D numpy array
             Image to apply the filters to.
-        
+
         Returns
         -------
         result: 2D numpy array or `LinearFilterChain`
@@ -286,7 +286,7 @@ class Gamma:
             self.B = None
         # Create the transformation matrices
         self._update_translation(dy, dx)
-    
+
     def _update_psf(self, psfs, center=None):
         """Update the psf convolution filter
         """
@@ -337,7 +337,8 @@ class Gamma:
                 gamma.append(LinearFilterChain([translation, self.psfFilters[b]]))
         return gamma
 
-class LinearOperator:
+import proxmin.utils
+class LinearOperator(proxmin.utils.MatrixAdapter):
     """Mock a linear operator
 
     Because scarlet uses 2D images for morphologies,
@@ -351,14 +352,16 @@ class LinearOperator:
         while isinstance(L, LinearOperator):
             L = L.L
         self.L = L
+        self.axis = 1
 
+    """
     def dot(self, X):
-        """Take the dot product with a 2D X
-        """
+        Take the dot product with a 2D X
         if isinstance(X, np.ndarray):
             return self.L.dot(X.reshape(-1)).reshape(X.shape)
         else:
-            return LinearOperator(self.L.dot(X))
+            return self.L.dot(X)
+    """
 
     @property
     def T(self):
@@ -393,7 +396,7 @@ class LinearOperator:
     @property
     def size(self):
         return self.L.size
-    
+
     @property
     def ndim(self):
         print(self.L.ndim)
@@ -422,12 +425,11 @@ class LinearOperator:
 
     def __rdiv__(self, op):
         return LinearOperator(self.L / op)
-    
+
     def reshape(self, shape):
         return LinearOperator(self.L.reshape(shape))
 
     def __array_prepare__(self, *args):
-        print("preparing")
         return self.L.__array_prepare__(*args)
 
     def __getattr__(self, attr):

--- a/scarlet/transformations.py
+++ b/scarlet/transformations.py
@@ -418,6 +418,7 @@ def getZeroOp(shape):
     except KeyError:
         # matrix with ones on diagonal shifted by k, here out of matrix: all zeros
         L = proxmin.utils.MatrixAdapter(scipy.sparse.eye(size, k=size), axis=1)
+        L._spec_norm = 0
         global cache
         cache[name][key] = L
     return L
@@ -431,6 +432,7 @@ def getIdentityOp(shape):
     except KeyError:
         # matrix with ones on diagonal shifted by k, here out of matrix: all zeros
         L = proxmin.utils.MatrixAdapter(scipy.sparse.identity(size), axis=1)
+        L._spec_norm = 1
         global cache
         cache[name][key] = L
     return L
@@ -452,6 +454,7 @@ def getSymmetryOp(shape):
         symmetryOp = getIdentityOp(shape).L
         symmetryOp -= scipy.sparse.coo_matrix((np.ones(size),(idx, sidx)), shape=(size,size))
         symmetryOp = proxmin.utils.MatrixAdapter(symmetryOp, axis=1)
+        _ = symmetryOp.spectral_norm
         global cache
         cache[name][key] = symmetryOp
     return symmetryOp
@@ -651,7 +654,7 @@ def getRadialMonotonicOp(shape, useNearest=True, minGradient=1, subtract=True):
         else:
             monotonic = cosArr
         monotonic = proxmin.utils.MatrixAdapter(monotonic.tocoo(), axis=1)
-
+        _ = monotonic.spectral_norm
         global cache
         cache[name][key] = monotonic
 

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
   url = 'https://github.com/fred3m/scarlet',
   keywords = ['astro', 'deblending', 'photometry', 'nmf'],
   ext_modules=ext_modules,
-  install_requires=['numpy', 'scipy', 'pybind11>=2.2', 'proxmin>=0.5.0', 'peigen>=0.0.9'],
+  install_requires=['numpy', 'scipy', 'pybind11>=2.2', 'proxmin>=0.5.1', 'peigen>=0.0.9'],
   cmdclass={'build_ext': BuildExt},
   zip_safe=False,
 )


### PR DESCRIPTION
This PR modifies `Constraint` to be an abstract implementation, which generates the relevant proximal operators and matrices, which are then subsequently adapted for each source.

This allows the constraints to be shared instead of copied (reducing memory cost and redundant operations) and strongly simplifies the constraint interface.

**Note:** Constraints are now generators of functions, not container of functions! This is necessary to allow the specialization for each source size.

As a bonus: factored out `Cache` to be used consistently in all modules of scarlet.