### PR TITLE
Resize without exception

### DIFF
--- a/scarlet/blend.py
+++ b/scarlet/blend.py
@@ -25,8 +25,24 @@ class ScarletRestartException(Exception):
 class Blend(ComponentTree):
     """The blended scene.
 
-    The class represents a celestial scene and provides the functions to fit it
+    The class represents a scene as collection of components, internally as a
+    `~scarlet.component.ComponentTree`, and provides the functions to fit it
     to data.
+
+    Attributes
+    ----------
+    B: int
+        Number of bands in the image data
+    has_psf: bool
+        Whether the modeled scene accounts for PSF convolution
+    it: int
+        Number of iterations run in the `fit` method
+    converged: `~numpy.array`
+        Array (K, 2) of convergence flags, one for each components sed and morph
+        in that order
+    mse: list
+        Array (it, 2) of mean squared errors in each iteration, for sed and morph
+        in that order
     """
     def __init__(self, components):
         """Constructor

--- a/scarlet/blend.py
+++ b/scarlet/blend.py
@@ -334,6 +334,8 @@ class Blend(ComponentTree):
 
                 # apply per component prox projection and save in component
                 res = self.components[k].constraints.prox_sed(X - step*grad, step)
+            else:
+                res = self.components[k].sed
 
         # S update
         elif block == 1:
@@ -357,6 +359,8 @@ class Blend(ComponentTree):
 
                 # apply per component prox projection and save in component
                 res = self.components[k].constraints.prox_morph(X - step*grad, step)
+            else:
+                res = self.components[k].morph
 
 
         # resize & recenter: after all blocks are updated

--- a/scarlet/blend.py
+++ b/scarlet/blend.py
@@ -323,7 +323,6 @@ class Blend(ComponentTree):
             else:
                 self.mse[-1][block] = mse
 
-
         # A update
         if block == 0:
             if not self.components[k].fix_sed:
@@ -333,13 +332,13 @@ class Blend(ComponentTree):
                 grad = np.einsum('...ij,...ij', self._diff, self._models[k])
 
                 # apply per component prox projection and save in component
-                res = self.components[k].constraints.prox_sed(X - step*grad, step)
+                X_ = self.components[k].constraints.prox_sed(X - step*grad, step)
             else:
-                res = self.components[k].sed
+                X_ = self.components[k].sed
 
         # S update
         elif block == 1:
-            if not self.components[k].fix_morph:
+            if not self.components[k].fix_morph:# and self.it % 2 != 0:
                 # gradient of likelihood wrt S: nominally np.dot(A^T,diff)
                 # but again: with convolution, it's more complicated
 
@@ -358,9 +357,9 @@ class Blend(ComponentTree):
                         grad += self.components[k].sed[b]*self.components[k].Gamma[b].T.dot(diff_k[b])
 
                 # apply per component prox projection and save in component
-                res = self.components[k].constraints.prox_morph(X - step*grad, step)
+                X_ = self.components[k].constraints.prox_morph(X - step*grad, step)
             else:
-                res = self.components[k].morph
+                X_ = self.components[k].morph
 
 
         # resize & recenter: after all blocks are updated
@@ -370,7 +369,7 @@ class Blend(ComponentTree):
             self.update_sed()
             self.update_morph()
 
-        return res
+        return X_
 
     def _one_over_lipschitz(self, block):
         """Calculate 1/Lipschitz constant for A and S

--- a/scarlet/component.py
+++ b/scarlet/component.py
@@ -301,7 +301,8 @@ class Component(object):
         if new_slice != old_slice:
             # change morph
             _morph = self.morph.copy()
-            self.morph = np.zeros(size)
+            self.morph.resize(size, refcheck=False)
+            self.morph[:,:] = 0
             self.morph[new_slice] = _morph[old_slice]
             self.set_frame()
 

--- a/scarlet/config.py
+++ b/scarlet/config.py
@@ -47,7 +47,7 @@ class Config(object):
         self.source_sizes = source_sizes
         self.center_min_dist = center_min_dist
         self.edge_flux_thresh = edge_flux_thresh
-        self.exact_lipschitz = False
+        self.exact_lipschitz = exact_lipschitz
         if source_sizes is None:
             source_sizes = np.array([15, 25, 45, 75, 115, 165])
         # Call `self.set_source_sizes` to ensure that all sizes are odd

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ class BuildExt(build_ext):
             ext.extra_compile_args = opts
         build_ext.build_extensions(self)
 
-install_requires = ['numpy', 'scipy', 'proxmin>=0.5.2']
+install_requires = ['numpy', 'scipy', 'proxmin>=0.5.3']
 # Only require the pybind11 and peigen packages if
 # the C++ headers are not already installed
 if pybind11_path is None:


### PR DESCRIPTION
uses proxmin 0.5.3 to change the box sizes on the fly.  Only important change for scarlet is that optimization parameters **cannot** be recreated, they need to be modified: https://github.com/fred3m/scarlet/compare/resize-mse?expand=1#diff-ef3b811b0e22d8a2268b81a55665ffd8R304