### PR TITLE
tickets/DM-20431: Implement Nate Lust's symmetry algorithm

### DIFF
--- a/docs/user_docs.ipynb
+++ b/docs/user_docs.ipynb
@@ -661,17 +661,6 @@
    ]
   },
   {
-   "cell_type": "raw",
-   "metadata": {
-    "raw_mimetype": "text/restructuredtext"
-   },
-   "source": [
-    ".. warning::\n",
-    "\n",
-    "    The current symmetry algorithm is broken and should not be used. A fix has been created and will be pushed to master in the coming weeks to reimplement a fast(er) symmetry algorithm that works properly."
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1040,7 +1029,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/scarlet/blend.py
+++ b/scarlet/blend.py
@@ -2,7 +2,6 @@ import autograd.numpy as np
 from autograd import grad
 
 from .component import ComponentTree, BlendFlag
-from .observation import Frame
 
 import logging
 

--- a/scarlet/observation.py
+++ b/scarlet/observation.py
@@ -187,6 +187,11 @@ class Observation():
             shape = np.array(model_frame.shape[1:]) + psf_shape - 1
             # Choose the optimal shape for FFTPack DFT
             self._fftpack_shape = [fftpack.helper.next_fast_len(d) for d in shape]
+            # autograd.numpy.fft does not currently work
+            # if the last dimension is odd
+            while self._fftpack_shape[-1] % 2 != 0:
+                _shape = self._fftpack_shape[-1] + 1
+                self._fftpack_shape[-1] = fftpack.helper.next_fast_len(_shape)
             # Store the pre-fftpack optimization slices
             self._slices = tuple([slice(s) for s in shape])
 

--- a/scarlet/operator.py
+++ b/scarlet/operator.py
@@ -1,6 +1,5 @@
 from functools import partial
 
-from scipy import fftpack
 import autograd.numpy as np
 from proxmin.operators import prox_unity_plus
 from proxmin.utils import MatrixAdapter
@@ -314,7 +313,7 @@ def prox_uncentered_symmetry(X, step, center=None, algorithm="kspace", fill=None
     algorithm: `string`
         The algorithm to use for symmetry.
         * If `algorithm = "kspace" then `X` is shifted by `shift` and
-          symmetry is performed in kspace. This is the only ymmetry algorithm
+          symmetry is performed in kspace. This is the only symmetry algorithm
           in scarlet that works for fractional pixel shifts.
         * If `algorithm = "sdss" then the SDSS symmetry is used,
           namely the source is made symmetric around the `center` pixel

--- a/scarlet/operator.py
+++ b/scarlet/operator.py
@@ -265,7 +265,6 @@ def prox_kspace_symmetry(X, step, shift=None, padding=10):
     edges = ((padding, padding), (padding, padding))
     corner = (padding, padding)
     zeroMask = X <= 0
-    X[zeroMask] = 0
     X = np.pad(X, edges, 'constant')
 
     freq_x = np.fft.fftfreq(X.shape[1])

--- a/scarlet/update.py
+++ b/scarlet/update.py
@@ -217,16 +217,25 @@ def translation(component, direction=1, kernel=interpolation.lanczos, padding=3)
 
 
 def psf_weighted_centroid(component):
+    """Calculate the fraction position of a component
+
+    Since our models should be relatively noise free it should be possible
+    to estimate the fractional pixel offset of a `Componet.morph` by
+    calculating the center of flux (centroid).
+    This method uses the frame PSF, if available, otherwise a narrow gaussian
+    is chosen such that that the flux is weighted to give more strength to
+    pixels closer to the `pixel_center`.
+    """
     # Extract the arrays from the component
     morph = component.morph
     if component.frame.psfs is None:
-        if not hasattr(component, "_centroid_psf"):
+        if not hasattr(component, "_centroid_weight"):
             shape = (41, 41)
             psf = generate_psf_image(gaussian, shape, amplitude=1, sigma=.9)
             psf /= psf.max()
-            component._centroid_psf = psf
+            component._centroid_weight = psf
         else:
-            psf = component._centroid_psf
+            psf = component._centroid_weight
     else:
         psf = component.frame.psfs[0]
 

--- a/scarlet/update.py
+++ b/scarlet/update.py
@@ -314,7 +314,6 @@ def symmetric(component, algorithm="kspace", bbox=None, fill=None, strength=.5):
         morph = component.morph
         shape = component.shape[-2:]
         center = pixel_center
-    morph = morph.copy()
 
     step_size = component.step_morph
     try:

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -109,6 +109,19 @@ class TestProx(object):
                   [16.0, 16.5, 17.0, 17.5, 18.0]]
         np.testing.assert_array_equal(_X, result)
 
+    def test_kspace_symmetry(self):
+        x = np.zeros((21, 21))
+        x[8:13, 8:13] = [
+            [1, 2, 3, 2, 1],
+            [2, 3, 4, 3, 1],
+            [3, 4, 5, 1, 1],
+            [2, 3, 1, 1, 1],
+            [1, 1, 1, 1, 1]
+        ]
+        _x = scarlet.operator.prox_kspace_symmetry(x, None, (0, 0))
+        symmetric = (x[::-1, ::-1] + x) / 2
+        np.testing.assert_almost_equal(_x, symmetric)
+
     def test_bulge_disk(self):
         disk_sed = np.arange(5)
         bulge_sed = np.arange(5)[::-1]

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -69,7 +69,7 @@ class TestPointSource(object):
         assert_array_equal(src.sed, seds[0])
         assert_array_equal(src.morph, truth)
         assert src.pixel_center == coords[0]
-        assert src.symmetric is False
+        assert src.symmetric is True
         assert src.monotonic is True
         assert src.center_step == 5
         assert src.delay_thresh == 10
@@ -79,8 +79,8 @@ class TestPointSource(object):
         src = scarlet.PointSource(frame, coords[0], obs)
 
         # We need to multiply by 4 because of psf normalization
-        assert_array_equal(src.sed*4, seds[0])
-        assert_array_equal(morphs[0], src.morph)
+        assert_almost_equal(src.sed*4, seds[0])
+        assert_almost_equal(morphs[0], src.morph)
         assert src.pixel_center == coords[0]
 
 
@@ -172,7 +172,7 @@ class TestExtendedSource(object):
         # Test ExtendedSource.__init__
         src = scarlet.ExtendedSource(frame, skycoord, observation, bg_rms)
         assert_array_equal(src.pixel_center, skycoord)
-        assert src.symmetric is False
+        assert src.symmetric is True
         assert src.monotonic is True
         assert src.center_step == 5
         assert src.delay_thresh == 10

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -205,7 +205,7 @@ class TestUpdate(object):
         src = scarlet.Component(frame, sed.copy(), morph.copy())
         src.L_morph = 1
         src.pixel_center = (2, 2)
-        update.symmetric(src, strength=.5)
+        update.symmetric(src, strength=.5, algorithm="soft")
         result = [[6.0, 6.5, 7.0, 7.5, 8.0],
                   [8.5, 9.0, 9.5, 10.0, 10.5],
                   [11.0, 11.5, 12.0, 12.5, 13.0],


### PR DESCRIPTION
Implement symmetry in kspace and fractional pixel shifts
calculated by using the morphology centroid weighted by
the frame psf.