### PR TITLE
Grad performance

### DIFF
--- a/docs/user_docs.ipynb
+++ b/docs/user_docs.ipynb
@@ -1029,7 +1029,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/scarlet/blend.py
+++ b/scarlet/blend.py
@@ -60,15 +60,6 @@ class Blend(ComponentTree):
                 return False
         return True
 
-    @property
-    def sources(self):
-        """Return the list of sources used in the blend.
-
-        This will be different than `Blend.components` when
-        some sources have multiple components.
-        """
-        return self.nodes
-
     def fit(self, max_iter=200, e_rel=1e-2, approximate_L=False):
         """Fit the model for each source to the data
 
@@ -113,8 +104,8 @@ class Blend(ComponentTree):
     def _backward(self):
         """Backpropagate the gradients for the seds and morphs
         """
-        seds = [src.sed for src in self.sources]
-        morphs = [src.morph for src in self.sources]
+        seds = [c.sed for c in self.components]
+        morphs = [c.morph for c in self.components]
         parameters = seds + morphs
         # This calculates the partial derivatives wrt
         # all the seds and morphologies
@@ -122,10 +113,9 @@ class Blend(ComponentTree):
         sed_gradients = gradients[:self.K]
         morph_gradients = gradients[self.K:]
         # set the sed and morphology gradients for each source
-        for k in range(self.K):
-            src = self.sources[k]
-            src.sed_grad = sed_gradients[k]
-            src.morph_grad = morph_gradients[k]
+        for k,c in enumerate(self.components):
+            c.sed_grad = sed_gradients[k]
+            c.morph_grad = morph_gradients[k]
 
     def _loss(self, *parameters):
         """Loss function for autograd

--- a/scarlet/blend.py
+++ b/scarlet/blend.py
@@ -41,6 +41,8 @@ class Blend(ComponentTree):
             observations = (observations,)
         self.observations = observations
 
+        n_params = 2 * self.K
+        self._grad = grad(self._loss, tuple(range(n_params)))
         self.mse = []
 
     @property
@@ -109,7 +111,7 @@ class Blend(ComponentTree):
         parameters = seds + morphs
         # This calculates the partial derivatives wrt
         # all the seds and morphologies
-        gradients = grad(self._loss, tuple(range(len(parameters))))(*parameters)
+        gradients = self._grad(*parameters)
         sed_gradients = gradients[:self.K]
         morph_gradients = gradients[self.K:]
         # set the sed and morphology gradients for each source

--- a/scarlet/component.py
+++ b/scarlet/component.py
@@ -284,7 +284,7 @@ class ComponentTree():
     def sources(self):
         """Initial list of components or sources that generate the tree.
 
-        This will be different than `self.components` because sources can
+        This can be different than `self.components` because sources can
         have multiple components.
 
         Returns
@@ -294,8 +294,15 @@ class ComponentTree():
         return self._tree
 
     @property
-    def n_nodes(self):
-        """Number of direct attached nodes.
+    def n_sources(self):
+        """Number of initial sources or components.
+
+        This can be different than `self.n_components` because sources can
+        have multiple components.
+
+        Returns
+        -------
+        int: number of initial sources
         """
         return len(self._tree)
 
@@ -367,7 +374,7 @@ class ComponentTree():
         ----------
         c: `~scarlet.component.Component` or `~scarlet.component.ComponentTree`
         """
-        c_index = self.n_nodes
+        c_index = self.n_sources
         if isinstance(c, ComponentTree):
             self._tree = self._tree + c._tree
         elif isinstance(c, Component):

--- a/scarlet/component.py
+++ b/scarlet/component.py
@@ -281,8 +281,11 @@ class ComponentTree():
         return self._tree[0].frame
 
     @property
-    def nodes(self):
-        """Initial list that generates the tree.
+    def sources(self):
+        """Initial list of components or sources that generate the tree.
+
+        This will be different than `self.components` because sources can
+        have multiple components.
 
         Returns
         -------

--- a/tests/test_blend.py
+++ b/tests/test_blend.py
@@ -86,8 +86,8 @@ class TestBlend(object):
         assert_almost_equal(images, model)
         assert blend.converged is False
 
-        for k in range(len(sources)):
-            assert_array_equal(blend.sources[k].get_model(), sources[k].get_model())
+        for s0, s in zip(sources, blend.sources):
+            assert_array_equal(s.get_model(), s0.get_model())
 
     def test_fit_point_source(self):
         shape = (6, 31, 55)
@@ -128,7 +128,7 @@ class TestBlend(object):
         # Scale the input psfs by the observation and model psfs to ensure
         # the sources were initialized correctly
         psf_scale = observation.frame.psfs.max(axis=(1, 2)) / frame.psfs[0].max()
-        scaled_seds = np.array([src.sed*psf_scale for src in blend.sources])
+        scaled_seds = np.array([c.sed*psf_scale for c in blend.components])
 
         assert_almost_equal(scaled_seds, seds)
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -172,8 +172,8 @@ class TestComponentTree(object):
         assert_array_equal(tree2.components, (c1, c2, c3))
         assert_array_equal(tree1.sources, (c1, c2))
         assert_array_equal(tree2.sources, (tree1, c3))
-        assert tree1.n_nodes == 2
-        assert tree2.n_nodes == 2
+        assert tree1.n_sources == 2
+        assert tree2.n_sources == 2
 
         # shapes
         assert tree1.K == 2
@@ -223,17 +223,17 @@ class TestComponentTree(object):
         # Test iadd
         tree1 += tree2
         assert tree1.n_components == 4
-        assert tree1.n_nodes == 4
+        assert tree1.n_sources == 4
         assert tree1.components == (c1, c2, c3, c4)
         assert tree1.sources == (c1, c2, c3, c4)
 
         tree1 += c5
         assert tree1.n_components == 5
-        assert tree1.n_nodes == 5
+        assert tree1.n_sources == 5
         assert tree1.components == (c1, c2, c3, c4, c5)
         assert tree1.sources == (c1, c2, c3, c4, c5)
         assert tree2.n_components == 2
-        assert tree2.n_nodes == 2
+        assert tree2.n_sources == 2
         assert tree2.components == (c3, c4)
         assert tree2.sources == (c3, c4)
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -170,8 +170,8 @@ class TestComponentTree(object):
         assert tree2.coord is None
         assert_array_equal(tree1.components, (c1, c2))
         assert_array_equal(tree2.components, (c1, c2, c3))
-        assert_array_equal(tree1.nodes, (c1, c2))
-        assert_array_equal(tree2.nodes, (tree1, c3))
+        assert_array_equal(tree1.sources, (c1, c2))
+        assert_array_equal(tree2.sources, (tree1, c3))
         assert tree1.n_nodes == 2
         assert tree2.n_nodes == 2
 
@@ -225,17 +225,17 @@ class TestComponentTree(object):
         assert tree1.n_components == 4
         assert tree1.n_nodes == 4
         assert tree1.components == (c1, c2, c3, c4)
-        assert tree1.nodes == (c1, c2, c3, c4)
+        assert tree1.sources == (c1, c2, c3, c4)
 
         tree1 += c5
         assert tree1.n_components == 5
         assert tree1.n_nodes == 5
         assert tree1.components == (c1, c2, c3, c4, c5)
-        assert tree1.nodes == (c1, c2, c3, c4, c5)
+        assert tree1.sources == (c1, c2, c3, c4, c5)
         assert tree2.n_components == 2
         assert tree2.n_nodes == 2
         assert tree2.components == (c3, c4)
-        assert tree2.nodes == (c3, c4)
+        assert tree2.sources == (c3, c4)
 
         # Test getitem
         tree1[0] == c1


### PR DESCRIPTION
This PR addresses #114 

It does fix a lapse in our `Blend._backward` code, which iterated over sources instead of components. In essence, the code only worked for single-component sources. I've corrected that and removed the redundant `nodes` in favor of the more obvious `sources` property. I needed to adjust 2 sets of tests.

However, the main idea was to call `grad` only once instead of dynamically recomputing the gradient tree. This has *no* performance gains I could find with timeit for our user guide blend, running for 100 iterations. The take-away is that our runtime is fully dominated by computing the gradients.