### PR TITLE
introduced measurement module

### DIFF
--- a/scarlet/measurement.py
+++ b/scarlet/measurement.py
@@ -1,0 +1,112 @@
+import numpy as np
+
+def max_pixel(morph, center=None, window=None):
+    """Use the pixel with the maximum flux as the center
+
+    In case there is a nearby bright neighbor, we only update
+    the center within the immediate vascinity of the previous center.
+    This allows the center to shift over time, but prevents a large,
+    likely unphysical update.
+
+    Parameters
+    ----------
+    window: tuple of slices
+        Slices in y and x of the central region to include in the fit.
+        If `window` is `None` then only the 3x3 grid of pixels centered
+        on the previous center are used. If it is desired to use the entire
+        morphology just set `window=(slice(None), slice(None))`.
+    """
+    if center is None:
+        shape = morph.shape
+        center = (shape[0]//2, shape[1]//2)
+    cy, cx = np.int(center[0]), np.int(center[1])
+
+    if window is None:
+        window = slice(cy-2, cy+3), slice(cx-2, cx+3)
+
+    _morph = morph[window]
+    yx0 = np.array([window[0].start, window[1].start])
+    return tuple(np.unravel_index(np.argmax(_morph), _morph.shape) + yx0)
+
+
+def psf_weighted_centroid(morph, psf, pixel_center):
+    """Calculate the fraction position of a component
+
+    Since our models should be relatively noise free it should be possible
+    to estimate the fractional pixel offset of a `Componet.morph` by
+    calculating the center of flux (centroid).
+    This method uses the frame PSF, if available, otherwise a narrow gaussian
+    is chosen such that that the flux is weighted to give more strength to
+    pixels closer to the `pixel_center`.
+    """
+    cy, cx = pixel_center
+
+    # Determine the width of the psf
+    psf_shape_y, psf_shape_x = psf.shape
+    # These are all the same value because psf are square and odd, but using
+    # multiple variable names to clarify things
+    x_rad = y_rad = psf_peak_y = psf_peak_x = psf_shape_x//2
+
+    # Determine the overlapping coordinates of the morphology image and the psf
+    # this is needed if the psf image, centered at the peak pixel location goes
+    # off the edge of the psf array
+    y_morph_ext = np.arange(morph.shape[0])
+    x_morph_ext = np.arange(morph.shape[1])
+
+    # calculate the offset in the morph frame such that the center pixel aligns
+    # with the psf coordindate frame, where the psf peak is in the center
+    y_morph_ext = y_morph_ext - cy
+    x_morph_ext = x_morph_ext - cx
+
+    # Compare the two end points, and take whichever is the smaller radius
+    # use that to select the entries that are equal to or below that radius
+    # Find the minimum between the end points (if the psf goes off the edge,
+    # and the radius of the psf
+    rad_endpoints_y = np.min((abs(y_morph_ext[0]), abs(y_morph_ext[-1]), y_rad))
+    rad_endpoints_x = np.min((abs(x_morph_ext[0]), abs(x_morph_ext[-1]), x_rad))
+    trimmed_y_range = y_morph_ext[abs(y_morph_ext) <= rad_endpoints_y]
+    trimmed_x_range = x_morph_ext[abs(x_morph_ext) <= rad_endpoints_x]
+
+    psf_y_range = trimmed_y_range + psf_peak_y
+    psf_x_range = trimmed_x_range + psf_peak_x
+
+    morph_y_range = trimmed_y_range + cy
+    morph_x_range = trimmed_x_range + cx
+
+    # Use these arrays to get views of the morphology and psf
+    morph_view = morph[morph_y_range][:, morph_x_range]
+    psf_view = psf[psf_y_range][:, psf_x_range]
+
+    morph_view_weighted = morph_view*psf_view
+    morph_view_weighted_sum = np.sum(morph_view_weighted)
+    # build the indices to use the the centroid calculation
+    indy, indx = np.indices(psf_view.shape)
+    first_moment_y = np.sum(indy*morph_view_weighted) / morph_view_weighted_sum
+    first_moment_x = np.sum(indx*morph_view_weighted) / morph_view_weighted_sum
+    # build the offset to go from psf_view frame to psf frame to morph frame
+    # aka move the peak back by the radius of the psf width adusted for the
+    # minimum point in the view
+    offset = (morph_y_range[0], morph_x_range[0])
+
+    whole_pixel_center = np.round((first_moment_y, first_moment_x))
+    dy, dx = whole_pixel_center - (first_moment_y, first_moment_x)
+    morph_pixel_center = tuple((whole_pixel_center + offset).astype(int))
+    return morph_pixel_center, (dy, dx)
+
+
+def threshold(morph):
+    """Find the threshold value for a given morphology
+    """
+    _morph = morph[morph > 0]
+    _bins = 50
+    # Decrease the bin size for sources with a small number of pixels
+    if _morph.size < 500:
+        _bins = max(np.int(_morph.size/10), 1)
+        if _bins == 1:
+            return 0, _bins
+    hist, bins = np.histogram(np.log10(_morph).reshape(-1), _bins)
+    cutoff = np.where(hist == 0)[0]
+    # If all of the pixels are used there is no need to threshold
+    if len(cutoff) == 0:
+        return 0, _bins
+    return 10**bins[cutoff[-1]], _bins

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -5,6 +5,7 @@ from . import operator
 from . import update
 from . import measurement
 from .interpolation import get_projection_slices
+from .psf import generate_psf_image, gaussian
 
 import logging
 

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -3,6 +3,7 @@ import autograd.numpy as np
 from .component import Component, ComponentTree
 from . import operator
 from . import update
+from . import measurement
 from .interpolation import get_projection_slices
 
 import logging
@@ -319,6 +320,18 @@ class PointSource(Component):
         self.monotonic = monotonic
         self.center_step = center_step
         self.delay_thresh = delay_thresh
+
+        # create PSF as weight for centroid measurements
+        if self.symmetric:
+            if self.frame.psfs is None:
+                shape = (41, 41)
+                psf = generate_psf_image(gaussian, shape, amplitude=1, sigma=.9)
+                psf /= psf.max()
+                self._centroid_weight = psf
+            else:
+                self._centroid_weight = self.frame.psfs[0]
+
+        # ensure adherence to constraints
         self.update()
 
     def update(self):
@@ -331,8 +344,10 @@ class PointSource(Component):
             it = 0
         else:
             it = self._parent.it
+
         # Update the central pixel location (pixel_center)
-        update.fit_pixel_center(self)
+        self.pixel_center = measurement.max_pixel(self.morph, self.pixel_center)
+
         # Thresholding needs to be fixed (DM-10190)
         # if it > self.delay_thresh:
         #     update.threshold(self)
@@ -346,7 +361,8 @@ class PointSource(Component):
         if self.symmetric:
             # Update the centroid position
             if it % 5 == 0:
-                update.psf_weighted_centroid(self)
+                self.pixel_center, self.shift = measurement.psf_weighted_centroid(self.morph, self._centroid_weight, self.pixel_center)
+
             # make the morphology perfectly symmetric
             update.symmetric(self, algorithm="kspace", bbox=bbox)
 
@@ -397,6 +413,17 @@ class ExtendedSource(PointSource):
                                           thresh, True, monotonic)
 
         Component.__init__(self, frame, sed, morph, **component_kwargs)
+
+        # create PSF as weight for centroid measurements
+        if self.symmetric:
+            if self.frame.psfs is None:
+                shape = (41, 41)
+                psf = generate_psf_image(gaussian, shape, amplitude=1, sigma=.9)
+                psf /= psf.max()
+                self._centroid_weight = psf
+            else:
+                self._centroid_weight = self.frame.psfs[0]
+
         self.update()
 
 

--- a/scarlet/update.py
+++ b/scarlet/update.py
@@ -5,40 +5,10 @@ from proxmin.operators import prox_plus, prox_hard, prox_soft
 
 from . import interpolation
 from . import operator
+from . import measurement
 from .bbox import trim
 from .cache import Cache
 from .psf import generate_psf_image, gaussian
-
-
-def _fit_pixel_center(morph, center, window=None):
-    cy, cx = np.int(center[0]), np.int(center[1])
-
-    if window is None:
-        window = slice(cy-2, cy+3), slice(cx-2, cx+3)
-
-    _morph = morph[window]
-    yx0 = np.array([window[0].start, window[1].start])
-    return tuple(np.unravel_index(np.argmax(_morph), _morph.shape) + yx0)
-
-
-def fit_pixel_center(component, window=None):
-    """Use the pixel with the maximum flux as the center
-
-    In case there is a nearby bright neighbor, we only update
-    the center within the immediate vascinity of the previous center.
-    This allows the center to shift over time, but prevents a large,
-    likely unphysical update.
-
-    Parameters
-    ----------
-    window: tuple of slices
-        Slices in y and x of the central region to include in the fit.
-        If `window` is `None` then only the 3x3 grid of pixels centered
-        on the previous center are used. If it is desired to use the entire
-        morphology just set `window=(slice(None), slice(None))`.
-    """
-    component.pixel_center = _fit_pixel_center(component.morph, component.pixel_center, window)
-    return component
 
 
 def positive_sed(component):
@@ -113,24 +83,6 @@ def sparse_l1(component, thresh):
     return component
 
 
-def _threshold(morph):
-    """Find the threshold value for a given morphology
-    """
-    _morph = morph[morph > 0]
-    _bins = 50
-    # Decrease the bin size for sources with a small number of pixels
-    if _morph.size < 500:
-        _bins = max(np.int(_morph.size/10), 1)
-        if _bins == 1:
-            return 0, _bins
-    hist, bins = np.histogram(np.log10(_morph).reshape(-1), _bins)
-    cutoff = np.where(hist == 0)[0]
-    # If all of the pixels are used there is no need to threshold
-    if len(cutoff) == 0:
-        return 0, _bins
-    return 10**bins[cutoff[-1]], _bins
-
-
 def threshold(component):
     """Set a cutoff threshold for pixels below the noise
 
@@ -143,7 +95,7 @@ def threshold(component):
     The region that contains flux above the threshold is contained
     in `component.bboxes["thresh"]`.
     """
-    thresh, _bins = _threshold(component.morph)
+    thresh, _bins = measurement.threshold(component.morph)
     component.morph[component.morph < thresh] = 0
     bbox = trim(component.morph)
     if not hasattr(component, "bboxes"):
@@ -213,86 +165,6 @@ def translation(component, direction=1, kernel=interpolation.lanczos, padding=3)
     dx *= direction
     _kernel, _, _ = interpolation.get_separable_kernel(dy, dx, kernel=kernel)
     component.morph[:] = interpolation.fft_resample(component.morph, dy, dx)
-    return component
-
-
-def psf_weighted_centroid(component):
-    """Calculate the fraction position of a component
-
-    Since our models should be relatively noise free it should be possible
-    to estimate the fractional pixel offset of a `Componet.morph` by
-    calculating the center of flux (centroid).
-    This method uses the frame PSF, if available, otherwise a narrow gaussian
-    is chosen such that that the flux is weighted to give more strength to
-    pixels closer to the `pixel_center`.
-    """
-    # Extract the arrays from the component
-    morph = component.morph
-    if component.frame.psfs is None:
-        if not hasattr(component, "_centroid_weight"):
-            shape = (41, 41)
-            psf = generate_psf_image(gaussian, shape, amplitude=1, sigma=.9)
-            psf /= psf.max()
-            component._centroid_weight = psf
-        else:
-            psf = component._centroid_weight
-    else:
-        psf = component.frame.psfs[0]
-
-    cy, cx = component.pixel_center
-
-    # Determine the width of the psf
-    psf_shape_y, psf_shape_x = psf.shape
-    # These are all the same value because psf are square and odd, but using
-    # multiple variable names to clarify things
-    x_rad = y_rad = psf_peak_y = psf_peak_x = psf_shape_x//2
-
-    # Determine the overlapping coordinates of the morphology image and the psf
-    # this is needed if the psf image, centered at the peak pixel location goes
-    # off the edge of the psf array
-    y_morph_ext = np.arange(morph.shape[0])
-    x_morph_ext = np.arange(morph.shape[1])
-
-    # calculate the offset in the morph frame such that the center pixel aligns
-    # with the psf coordindate frame, where the psf peak is in the center
-    y_morph_ext = y_morph_ext - cy
-    x_morph_ext = x_morph_ext - cx
-
-    # Compare the two end points, and take whichever is the smaller radius
-    # use that to select the entries that are equal to or below that radius
-    # Find the minimum between the end points (if the psf goes off the edge,
-    # and the radius of the psf
-    rad_endpoints_y = np.min((abs(y_morph_ext[0]), abs(y_morph_ext[-1]), y_rad))
-    rad_endpoints_x = np.min((abs(x_morph_ext[0]), abs(x_morph_ext[-1]), x_rad))
-    trimmed_y_range = y_morph_ext[abs(y_morph_ext) <= rad_endpoints_y]
-    trimmed_x_range = x_morph_ext[abs(x_morph_ext) <= rad_endpoints_x]
-
-    psf_y_range = trimmed_y_range + psf_peak_y
-    psf_x_range = trimmed_x_range + psf_peak_x
-
-    morph_y_range = trimmed_y_range + cy
-    morph_x_range = trimmed_x_range + cx
-
-    # Use these arrays to get views of the morphology and psf
-    morph_view = morph[morph_y_range][:, morph_x_range]
-    psf_view = psf[psf_y_range][:, psf_x_range]
-
-    morph_view_weighted = morph_view*psf_view
-    morph_view_weighted_sum = np.sum(morph_view_weighted)
-    # build the indices to use the the centroid calculation
-    indy, indx = np.indices(psf_view.shape)
-    first_moment_y = np.sum(indy*morph_view_weighted) / morph_view_weighted_sum
-    first_moment_x = np.sum(indx*morph_view_weighted) / morph_view_weighted_sum
-    # build the offset to go from psf_view frame to psf frame to morph frame
-    # aka move the peak back by the radius of the psf width adusted for the
-    # minimum point in the view
-    offset = (morph_y_range[0], morph_x_range[0])
-
-    whole_pixel_center = np.round((first_moment_y, first_moment_x))
-    dy, dx = whole_pixel_center - (first_moment_y, first_moment_x)
-    morph_pixel_center = tuple((whole_pixel_center + offset).astype(int))
-    component.pixel_center = morph_pixel_center
-    component.shift = (dy, dx)
     return component
 
 

--- a/scarlet/update.py
+++ b/scarlet/update.py
@@ -8,7 +8,6 @@ from . import operator
 from . import measurement
 from .bbox import trim
 from .cache import Cache
-from .psf import generate_psf_image, gaussian
 
 
 def positive_sed(component):

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -3,6 +3,7 @@ import numpy as np
 
 import scarlet
 import scarlet.update as update
+import scarlet.measurement as measurement
 from scarlet.cache import Cache
 
 
@@ -12,27 +13,12 @@ class TestUpdate(object):
         morph[4, 7] = 1
         morph[11, 9] = 2
         # Use the default window, which misses the higher point
-        center = update._fit_pixel_center(morph, (5, 5))
+        center = measurement.max_pixel(morph, (5, 5))
         np.testing.assert_array_equal([4, 7], center)
 
         # Make window wider and test again
-        center = update._fit_pixel_center(morph, (5, 5), window=tuple([slice(0, 15)] * 2))
+        center = measurement.max_pixel(morph, (5, 5), window=tuple([slice(0, 15)] * 2))
         np.testing.assert_array_equal([11, 9], center)
-
-        # Same tests but using the component
-        sed = np.array([1, 0, 2, 4, 10])
-        shape = (len(sed), morph.shape[0], morph.shape[1])
-        frame = scarlet.Frame(shape)
-
-        src = scarlet.Component(frame, sed, morph)
-        src.pixel_center = (5, 5)
-        update.fit_pixel_center(src)
-        np.testing.assert_array_equal([4, 7], src.pixel_center)
-
-        src = scarlet.Component(frame, sed, morph)
-        src.pixel_center = (5, 5)
-        update.fit_pixel_center(src, window=tuple([slice(0, 15)] * 2))
-        np.testing.assert_array_equal([11, 9], src.pixel_center)
 
     def test_non_negativity(self):
         sed = np.array([-.1, .1, 4, -.2, .2, 0])
@@ -121,7 +107,7 @@ class TestUpdate(object):
         shape = (len(sed), morph.shape[0], morph.shape[1])
         frame = scarlet.Frame(shape)
         src = scarlet.Component(frame, sed.copy(), morph.copy())
-        thresh, _ = update._threshold(src.morph)
+        thresh, _ = measurement.threshold(src.morph)
         true_morph = np.zeros(morph.shape)
         true_morph[7:14, 7:14] = morph[7:14, 7:14]
         update.threshold(src)


### PR DESCRIPTION
Methods that measure something off morphologies or sed or full data cubes in the model space are put into this new module. this clarifies where such methods go, and the methods don't use the full `component` as argument and then set implicit attributes. Instead, this is now done explicitly by the `update` methods.