### PR TITLE
Fastfft symmetry

### DIFF
--- a/scarlet/operator.py
+++ b/scarlet/operator.py
@@ -269,13 +269,16 @@ def prox_kspace_symmetry(X, step, shift=None, padding=10):
 
     convshape = 2*np.array(shape)-1
     from scipy import fftpack
-    fast_shape = shape#[fftpack.helper.next_fast_len(d) for d in convshape]
+    fast_shape = [fftpack.helper.next_fast_len(d) for d in convshape]
+
+    # Store the pre-fftpack optimization slices
+    slices = tuple(([slice(s) for s in convshape]))
 
     freq_x = np.fft.fftfreq(fast_shape[1])
     freq_y = np.fft.fftfreq(fast_shape[0])
 
     # Transform to k space
-    X_fft = np.fft.fftn(np.fft.ifftshift(X), fast_shape)
+    X_fft = np.fft.fftn(X, fast_shape)
 
     # Shift the signal to recenter it, negative because math is opposite from
     # pixel direction
@@ -292,7 +295,7 @@ def prox_kspace_symmetry(X, step, shift=None, padding=10):
     result_fft = result_fft*inv_shifter
 
     # Transform to real space
-    result = np.fft.fftshift(np.fft.irfftn(result_fft, fast_shape))
+    result = np.fft.ifftshift(np.fft.irfftn(result_fft, fast_shape))#[slices]
 
     # Return the unpadded transform
     #result = np.real(result[corner[0]:corner[0]+shape[0], corner[1]:corner[1]+shape[1]])
@@ -302,10 +305,14 @@ def prox_kspace_symmetry(X, step, shift=None, padding=10):
     result[zeroMask] = 0
 
     import matplotlib.pyplot as plt
-    plt.imshow(result)
+    plt.imshow(X)
     plt.colorbar()
     plt.show()
 
+    plt.imshow(np.real(shifter))
+    plt.show()
+    plt.imshow(np.real(X_fft))
+    plt.show()
     assert result.shape == shape
     return result
 

--- a/scarlet/operator.py
+++ b/scarlet/operator.py
@@ -264,7 +264,7 @@ def prox_kspace_symmetry(X, step, shift=None, padding=10):
     # Record the morph shape
     shape = X.shape
     #fast shapes for acceleration
-    _fftpack_shape = [fftpack.helper.next_fast_len(d) for d in (2 * (np.array(X.shape)+padding) - 1)]
+    _fftpack_shape = [fftpack.helper.next_fast_len(d) for d in ((np.array(X.shape)+padding))]
 
     dy, dx = shift
     #padding with fast shape

--- a/scarlet/operator.py
+++ b/scarlet/operator.py
@@ -4,6 +4,9 @@ import numpy as np
 from proxmin.operators import prox_unity_plus
 from proxmin.utils import MatrixAdapter
 
+from . import observation
+from scipy import fftpack
+
 from .cache import Cache
 
 
@@ -260,60 +263,44 @@ def prox_kspace_symmetry(X, step, shift=None, padding=10):
     """
     # Record the morph shape
     shape = X.shape
+    #fast shapes for acceleration
+    _fftpack_shape = [fftpack.helper.next_fast_len(d) for d in (2 * (np.array(X.shape)+padding) - 1)]
+
     dy, dx = shift
-    padding = np.max(X.shape) + padding // 2
-    edges = ((padding, padding), (padding, padding))
-    corner = (padding, padding)
+    #padding with fast shape
+    padding = (np.array(_fftpack_shape) - X.shape+padding)//2
+
     zeroMask = X <= 0
-    X = np.pad(X, edges, 'constant')
-
-    convshape = 2*np.array(shape)-1
-    from scipy import fftpack
-    fast_shape = [fftpack.helper.next_fast_len(d) for d in convshape]
-
-    # Store the pre-fftpack optimization slices
-    slices = tuple(([slice(s) for s in convshape]))
-
-    freq_x = np.fft.fftfreq(fast_shape[1])
-    freq_y = np.fft.fftfreq(fast_shape[0])
+    X = np.pad(X, ((padding[0], padding[0]),(padding[1], padding[1])), 'constant')
 
     # Transform to k space
-    X_fft = np.fft.fftn(X, fast_shape)
+    X_fft = np.fft.fftn(np.fft.ifftshift(X))
+
+    freq_x = np.fft.fftfreq(X_fft.shape[1])
+    freq_y = np.fft.fftfreq(X_fft.shape[0])
 
     # Shift the signal to recenter it, negative because math is opposite from
     # pixel direction
-    shifter = np.outer(np.exp(-1j*2*np.pi*freq_y*-(dy)),
-                       np.exp(-1j*2*np.pi*freq_x*-(dx)))
-    inv_shifter = np.outer(np.exp(-1j*2*np.pi*freq_y*(dy)),
-                           np.exp(-1j*2*np.pi*freq_x*(dx)))
-    result_fft = X_fft*shifter
+    shifter = np.outer(np.exp(-1j * 2 * np.pi * freq_y * -(dy)),
+                       np.exp(-1j * 2 * np.pi * freq_x * -(dx)))
+    inv_shifter = np.outer(np.exp(-1j * 2 * np.pi * freq_y * (dy)),
+                           np.exp(-1j * 2 * np.pi * freq_x * (dx)))
+    result_fft = X_fft * shifter
 
     # symmeterize
     result_fft = result_fft.real
 
     # Shift back
-    result_fft = result_fft*inv_shifter
+    result_fft = result_fft * inv_shifter
 
     # Transform to real space
-    result = np.fft.ifftshift(np.fft.irfftn(result_fft, fast_shape))#[slices]
-
+    result = np.fft.fftshift(np.fft.ifftn(result_fft))
     # Return the unpadded transform
-    #result = np.real(result[corner[0]:corner[0]+shape[0], corner[1]:corner[1]+shape[1]])
-    from . import observation
-    result = observation._centered(result, shape)
-    print(result.shape)
+    result = observation._centered(np.real(result), shape)
     result[zeroMask] = 0
-
-    import matplotlib.pyplot as plt
-    plt.imshow(X)
-    plt.colorbar()
-    plt.show()
-
-    plt.imshow(np.real(shifter))
-    plt.show()
-    plt.imshow(np.real(X_fft))
-    plt.show()
     assert result.shape == shape
+
+
     return result
 
 


### PR DESCRIPTION
A quick and cheap trick to have fast shapes in symmetry. This is just a padding of the morphologies with a fast fft shape. The gain is pretty great! 
Before PR #107 the runtime for quickstart was ~20ms 
After PR #107, it went to ~80ms
Now we are back to ~20ms