### PR TITLE
Bugfix sed

### DIFF
--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -245,7 +245,7 @@
    "metadata": {},
    "source": [
     "### View the source models\n",
-    "It can also be useful to view the model for each source, in its original frame and in its observed frame. In this example, the two frame differ by an extra convolution from the minimal `model_psf` constructed above to the observed psfs."
+    "It can also be useful to view the model for each source, in its original frame and in its observed frame. In this example, the two frames differ by an extra convolution from the minimal `model_psf` constructed above to the observed psfs."
    ]
   },
   {

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -46,7 +46,6 @@
    "source": [
     "# Load the sample images\n",
     "data = np.load(\"../data/hsc_cosmos_35.npz\")\n",
-    "\n",
     "images = data[\"images\"]\n",
     "filters = data[\"filters\"]\n",
     "psfs = data[\"psfs\"]\n",
@@ -73,7 +72,7 @@
    "source": [
     "from astropy.visualization.lupton_rgb import AsinhMapping, LinearMapping\n",
     "\n",
-    "stretch = 1\n",
+    "stretch = 0.1\n",
     "Q = 10\n",
     "norm = AsinhMapping(minimum=0, stretch=stretch, Q=Q)\n",
     "img_rgb = scarlet.display.img_to_rgb(images, norm=norm)\n",
@@ -154,7 +153,7 @@
     "sources = []\n",
     "for src in catalog:\n",
     "    try:\n",
-    "        new_source = scarlet.ExtendedSource(frame, (src['y'], src['x']), observation, bg_rms)\n",
+    "        new_source = scarlet.ExtendedSource(frame, (src['y'], src['x']), observation, bg_rms, symmetric=True)\n",
     "    except scarlet.SourceInitError:\n",
     "        try:\n",
     "            new_source = scarlet.PointSource(frame, (src['y'], src['x']), observation)\n",
@@ -186,13 +185,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "blend = scarlet.Blend(sources, observation)\n",
-    "blend.fit(200, e_rel=1e-3)"
+    "%time blend.fit(200, e_rel=1e-3)\n",
+    "print(\"scarlet ran for {0} iterations to MSE = {1}\".format(len(blend.mse), blend.mse[-1]))\n",
+    "plt.semilogy(blend.mse)"
    ]
   },
   {
@@ -207,7 +206,7 @@
    "metadata": {},
    "source": [
     "### View the full model\n",
-    "First we load the model for the entire blend and its residual. Then we display the model using the same $sinh^{-1}$ stretch as the full image and a linear stretch for the residual."
+    "First we load the model for the entire blend, render it in the observation frame, and compute its residuals. We then show each using the same $sinh^{-1}$ stretch as the full image and a linear stretch for the residual."
    ]
   },
   {
@@ -236,8 +235,8 @@
     "\n",
     "for k,component in enumerate(blend.components):\n",
     "    y,x = component.pixel_center\n",
-    "    ax[0].text(x, y, k, color=\"b\")\n",
-    "    ax[1].text(x, y, k, color=\"b\")\n",
+    "    ax[0].text(x, y, k, color=\"w\")\n",
+    "    ax[1].text(x, y, k, color=\"w\")\n",
     "plt.show()"
    ]
   },
@@ -246,7 +245,7 @@
    "metadata": {},
    "source": [
     "### View the source models\n",
-    "It can also be useful to view the model for each source. For each source we extract the portion of the image contained in the sources bounding box, the true simulated source flux, and the model of the source, scaled so that all of the images have roughly the same pixel scale."
+    "It can also be useful to view the model for each source, in its original frame and in its observed frame. In this example, the two frame differ by an extra convolution from the minimal `model_psf` constructed above to the observed psfs."
    ]
   },
   {
@@ -257,21 +256,6 @@
    },
    "outputs": [],
    "source": [
-    "def get_true_image(m, catalog, filters):\n",
-    "    \"\"\"Create the true multiband image for a source\n",
-    "    \"\"\"\n",
-    "    img = np.array([np.sum(catalog[catalog[\"index\"]==m][\"intensity_\"+f], axis=0) for f in filters])\n",
-    "    return img\n",
-    "\n",
-    "# We can only show the true values if the input catalog has the true intensity data for the sources\n",
-    "# in other words, if you used SEP to build your catalog you do not have the true data.\n",
-    "if \"intensity_\"+filters[0] in catalog.dtype.names:\n",
-    "    has_truth = True\n",
-    "    axes = 3\n",
-    "else:\n",
-    "    has_truth = False\n",
-    "    axes = 2\n",
-    "\n",
     "# Set the stretch based on the model\n",
     "stretch = .3\n",
     "Q = 10\n",
@@ -281,36 +265,32 @@
     "    # Get the model for a single source\n",
     "    model = src.get_model()\n",
     "    model_ = observation.render(model)\n",
-    "    model_rgb = scarlet.display.img_to_rgb(model_, norm=norm)\n",
-    "    # Get the patch from the original image\n",
+    "    \n",
+    "    # Convert observation and models to RGB\n",
     "    img_rgb = scarlet.display.img_to_rgb(images, norm=norm)\n",
+    "    model_rgb = scarlet.display.img_to_rgb(model, norm=norm)\n",
+    "    model_rgb_ = scarlet.display.img_to_rgb(model_, norm=norm)\n",
+    "\n",
     "    # Set the figure size\n",
     "    ratio = src.shape[2]/src.shape[1]\n",
     "    fig_height = 3*src.shape[1]/20\n",
     "    fig_width = max(2*fig_height*ratio,2)\n",
     "    fig = plt.figure(figsize=(fig_width, fig_height))\n",
+    "    \n",
     "    # Generate and show the figure\n",
-    "    ax = [fig.add_subplot(1,2,n+1) for n in range(2)]\n",
+    "    ax = [fig.add_subplot(1,3,n+1) for n in range(3)]\n",
     "    ax[0].imshow(img_rgb)\n",
     "    ax[0].set_title(\"Data\")\n",
-    "    ax[1].imshow(model_rgb)\n",
-    "    ax[1].set_title(\"model {0}\".format(k))\n",
+    "    ax[1].imshow(model_rgb_)\n",
+    "    ax[1].set_title(\"Observed model {0}\".format(k))\n",
+    "    ax[2].imshow(model_rgb)\n",
+    "    ax[2].set_title(\"Model {0}\".format(k))\n",
     "    # Mark the source in the data image\n",
     "    ax[0].plot(src.pixel_center[1], src.pixel_center[0], \"rx\", mew=2, ms=10)\n",
+    "    ax[1].plot(src.pixel_center[1], src.pixel_center[0], \"rx\", mew=2, ms=10)\n",
+    "    ax[2].plot(src.pixel_center[1], src.pixel_center[0], \"rx\", mew=2, ms=10)\n",
     "    plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {
@@ -330,7 +310,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -153,7 +153,7 @@
     "sources = []\n",
     "for src in catalog:\n",
     "    try:\n",
-    "        new_source = scarlet.ExtendedSource(frame, (src['y'], src['x']), observation, bg_rms, symmetric=True)\n",
+    "        new_source = scarlet.ExtendedSource(frame, (src['y'], src['x']), observation, bg_rms)\n",
     "    except scarlet.SourceInitError:\n",
     "        try:\n",
     "            new_source = scarlet.PointSource(frame, (src['y'], src['x']), observation)\n",

--- a/docs/user_docs.ipynb
+++ b/docs/user_docs.ipynb
@@ -493,10 +493,7 @@
     "            ax[-1].set_xlabel(\"Band\")\n",
     "            ax[-1].set_ylabel(\"Intensity\")\n",
     "        # Mark the current source in the image\n",
-    "        if components > 1:\n",
-    "            y,x = src.components[0].pixel_center\n",
-    "        else:\n",
-    "            y,x = src.pixel_center\n",
+    "        y,x = src.pixel_center\n",
     "        ax[0].plot(x-bb[2].start, y-bb[1].start, 'rx', mew=2)\n",
     "        plt.tight_layout()\n",
     "        plt.show()"
@@ -547,7 +544,7 @@
     "    for src in catalog\n",
     "]\n",
     "# Show the initial guess for the brightest four sources\n",
-    "display_sources(sources[:4], observation, norm=asinh)"
+    "display_sources(sources, observation, norm=asinh)"
    ]
   },
   {
@@ -772,11 +769,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "blend.fit(30)\n",
+    "blend.fit(10)\n",
     "print(blend.it) \n",
-    "blend.fit(30)\n",
+    "blend.fit(10)\n",
     "print(blend.it)\n",
-    "blend.fit(30)\n",
+    "blend.fit(10)\n",
     "print(blend.it)"
    ]
   },

--- a/scarlet/component.py
+++ b/scarlet/component.py
@@ -363,8 +363,8 @@ class ComponentTree():
         perform updates on multiple components at once
         (for example separating a buldge and disk).
         """
-        for component in self.components:
-            component.update()
+        for node in self._tree:
+            node.update()
 
     def __iadd__(self, c):
         """Add another component or tree.

--- a/scarlet/source.py
+++ b/scarlet/source.py
@@ -251,10 +251,10 @@ def init_multicomponent_source(sky_coord, frame, observation, bg_rms, flux_perce
 
     # renormalize morphs: initially Smax
     for k in range(K):
-        morphs[k] /= morphs[k].max()
         if np.all(morphs[k] <= 0):
             msg = "Zero or negative morphology for component {} at y={}, x={}"
             logger.warning(msg.format(k, *skycoords))
+        morphs[k] /= morphs[k].max()
 
     # optimal SEDs given the morphologies, assuming img only has that source
     seds = get_best_fit_seds(morphs, frame, observation)

--- a/scarlet/update.py
+++ b/scarlet/update.py
@@ -167,13 +167,12 @@ def translation(component, direction=1, kernel=interpolation.lanczos, padding=3)
     return component
 
 
-def symmetric(component, algorithm="kspace", bbox=None, fill=None, strength=.5):
+def symmetric(component, pixel_center, algorithm="kspace", bbox=None, fill=None, strength=.5):
     """Make the source symmetric about its center
 
     See `~scarlet.operator.prox_uncentered_symmetry`
     for a description of the parameters.
     """
-    pixel_center = component.pixel_center
     if bbox is not None:
         # Only apply monotonicity to the pixels inside the bounding box
         morph = component.morph[bbox.slices]

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -45,11 +45,6 @@ class TestPointSource(object):
         sed = np.concatenate([scarlet.source.get_pixel_sed(skycoord, obs) for obs in observations])
         assert_array_equal(sed, true_sed)
 
-        with pytest.raises(SourceInitError):
-            images = images1 - 200
-            obs = scarlet.Observation(images)
-            sed = scarlet.source.get_pixel_sed(skycoord, obs)
-
     def test_point_source(self):
         shape = (5, 11, 21)
         coords = [(4, 8), (8, 11), (5, 16)]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -184,7 +184,7 @@ class TestUpdate(object):
         src = scarlet.Component(frame, sed.copy(), morph.copy())
         src.L_morph = 1
         src.pixel_center = (2, 2)
-        update.symmetric(src)
+        update.symmetric(src, src.pixel_center)
         result = np.ones_like(morph) * 12
         np.testing.assert_array_equal(src.morph, result)
 
@@ -192,7 +192,7 @@ class TestUpdate(object):
         src = scarlet.Component(frame, sed.copy(), morph.copy())
         src.L_morph = 1
         src.pixel_center = (2, 2)
-        update.symmetric(src, strength=.5, algorithm="soft")
+        update.symmetric(src, src.pixel_center, strength=.5, algorithm="soft")
         result = [[6.0, 6.5, 7.0, 7.5, 8.0],
                   [8.5, 9.0, 9.5, 10.0, 10.5],
                   [11.0, 11.5, 12.0, 12.5, 13.0],
@@ -204,7 +204,7 @@ class TestUpdate(object):
         src = scarlet.Component(frame, sed.copy(), morph.copy())
         src.L_morph = 1
         src.pixel_center = (1, 1)
-        update.symmetric(src)
+        update.symmetric(src, src.pixel_center)
         result = morph.copy()
         result[:3, :3] = 6
         np.testing.assert_array_equal(src.morph, result)


### PR DESCRIPTION
SED initialization code was not robust for negative/zero flux in some bands. As such, such an SED is not a problem. I therefore changed the behavior from raising an exception to logging a warning.

I also, moved the SED correction (for PSF width variations) from `get_pixel_sed` to the relevant `init_` functions because this is where it's needed. It's confusing otherwise.